### PR TITLE
fix(backstage-techdocs): remove techdocs reference

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,6 @@ metadata:
   description: "test-demo"
   annotations:
     github.com/project-slug: cultureamp/mjwalf-test
-    backstage.io/techdocs-ref: url:https://github.com/cultureamp/mjwalf-test
     buildkite.com/project-slug: culture-amp/mjwalf-test
 spec:
   type: service


### PR DESCRIPTION
Remove the references to non-existent backstage tech docs files.

References to non-existent files causes backstage 404.